### PR TITLE
tst+fix: initial travis support, credential-less boto3 usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - AWS_SECRET_ACCESS_KEY=bar
 
 install:
-  - pip install -e .
+  - pip install -e .[tests]
 
 script:
   - py.test -v awsbatcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+# vim ft=yaml
+language: python
+sudo: false
+cache:
+  directories:
+    - $HOME/.cache/pip
+
+python:
+  - 3.5
+  - 3.6
+
+env:
+  global:
+    # to allow AWS S3 to work
+    - AWS_ACCESS_KEY_ID=foo
+    - AWS_SECRET_ACCESS_KEY=bar
+
+script:
+  - py.test -v awsbatcher

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     # to allow AWS S3 to work
     - AWS_ACCESS_KEY_ID=foo
     - AWS_SECRET_ACCESS_KEY=bar
+    - AWS_SESSION_TOKEN=baz
 
 install:
   - pip install -e .[tests]

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,8 @@ env:
     - AWS_ACCESS_KEY_ID=foo
     - AWS_SECRET_ACCESS_KEY=bar
 
+install:
+  - pip install -e .
+
 script:
   - py.test -v awsbatcher

--- a/awsbatcher/cli/tests/test_submissions.py
+++ b/awsbatcher/cli/tests/test_submissions.py
@@ -1,10 +1,8 @@
 import pytest
-from moto import mock_s3
 
 from awsbatcher import PROJECTS_DIR
 from awsbatcher.cli.run import main as submit
 
-@mock_s3
 @pytest.mark.parametrize('dataset', list(PROJECTS_DIR.keys()))
 def test_datasets(tmpdir, dataset):
     args = [dataset, 'job-queue', 'job-definition', '--dry']

--- a/awsbatcher/cli/tests/test_submissions.py
+++ b/awsbatcher/cli/tests/test_submissions.py
@@ -1,0 +1,9 @@
+import pytest
+
+from awsbatcher import PROJECTS_DIR
+from awsbatcher.cli.run import main as submit
+
+@pytest.mark.parametrize('dataset', list(PROJECTS_DIR.keys()))
+def test_datasets(tmpdir, dataset):
+    args = [dataset, 'job-queue', 'job-definition', '--dry']
+    submit(args)

--- a/awsbatcher/cli/tests/test_submissions.py
+++ b/awsbatcher/cli/tests/test_submissions.py
@@ -1,8 +1,10 @@
 import pytest
+from moto import mock_s3
 
 from awsbatcher import PROJECTS_DIR
 from awsbatcher.cli.run import main as submit
 
+@mock_s3
 @pytest.mark.parametrize('dataset', list(PROJECTS_DIR.keys()))
 def test_datasets(tmpdir, dataset):
     args = [dataset, 'job-queue', 'job-definition', '--dry']

--- a/awsbatcher/info.py
+++ b/awsbatcher/info.py
@@ -8,4 +8,5 @@ __requires__ = [
     "requests",
     "bs4",
     "boto3",
+    "pytest",
 ]

--- a/awsbatcher/info.py
+++ b/awsbatcher/info.py
@@ -12,7 +12,6 @@ __requires__ = [
 ]
 __tests_requires__ = [
     "pytest",
-    "moto",
 ]
 
 __extra_requires__ = {

--- a/awsbatcher/info.py
+++ b/awsbatcher/info.py
@@ -9,4 +9,5 @@ __requires__ = [
     "bs4",
     "boto3",
     "pytest",
+    "lxml",
 ]

--- a/awsbatcher/info.py
+++ b/awsbatcher/info.py
@@ -8,6 +8,13 @@ __requires__ = [
     "requests",
     "bs4",
     "boto3",
-    "pytest",
     "lxml",
 ]
+__tests_requires__ = [
+    "pytest",
+    "moto",
+]
+
+__extra_requires__ = {
+    "tests": __tests_requires__,
+}

--- a/awsbatcher/parser.py
+++ b/awsbatcher/parser.py
@@ -2,6 +2,8 @@ import os.path as op
 import requests
 
 import boto3
+from botocore import UNSIGNED
+from botocore.client import Config
 from bs4 import BeautifulSoup
 
 MAX_ARRAY_JOBS = 350
@@ -92,7 +94,7 @@ def fetch_s3_data(s3_url, batcher):
         bpath = s3_path[1]
     bucket = s3_path[0]
 
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client('s3', config=Config(signature_version=UNSIGNED))
     samples = s3_client.list_objects(Bucket=bucket, Prefix=bpath, Delimiter='/')
     for res in samples.get('CommonPrefixes'):
         # relative path from bucket root

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ setup(
     author_email=ldict['__email__'],
     packages=find_packages(),
     install_requires=ldict['__requires__'],
+    tests_require=ldict['__tests_requires__'],
+    extras_require=ldict['__extra_requires__'],
     include_package_data=True,
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
* Adds very basic test coverage for queuing supported projects
* Reworks `boto3` usage to not verify credentials
* Adds `pytest` to testing dependencies.
   * to install, use `[tests]` extras argument